### PR TITLE
fix(backend): restrict uploads to images

### DIFF
--- a/backend/routes/uploadRoutes.js
+++ b/backend/routes/uploadRoutes.js
@@ -1,6 +1,7 @@
 import path from 'path';
 import express from 'express';
 import multer from 'multer';
+
 const router = express.Router();
 
 const storage = multer.diskStorage({
@@ -15,26 +16,33 @@ const storage = multer.diskStorage({
   },
 });
 
-function checkFileType(file, cb) {
-  const filetypes = /jpg|jpeg|png/;
+function fileFilter(req, file, cb) {
+  const filetypes = /jpe?g|png|webp/;
+  const mimetypes = /image\/jpe?g|image\/png|image\/webp/;
+
   const extname = filetypes.test(path.extname(file.originalname).toLowerCase());
-  const mimetype = filetypes.test(file.mimetype);
+  const mimetype = mimetypes.test(file.mimetype);
 
   if (extname && mimetype) {
-    return cb(null, true);
+    cb(null, true);
   } else {
-    cb({ message: 'Images only!' });
+    cb(new Error('Images only!'), false);
   }
 }
 
-const upload = multer({
-  storage,
-});
+const upload = multer({ storage, fileFilter });
+const uploadSingleImage = upload.single('image');
 
-router.post('/', upload.single('image'), (req, res) => {
-  res.send({
-    message: 'Image uploaded successfully',
-    image: `/${req.file.path}`,
+router.post('/', (req, res) => {
+  uploadSingleImage(req, res, function (err) {
+    if (err) {
+      res.status(400).send({ message: err.message });
+    }
+
+    res.status(200).send({
+      message: 'Image uploaded successfully',
+      image: `/${req.file.path}`,
+    });
   });
 });
 

--- a/readme.md
+++ b/readme.md
@@ -130,6 +130,12 @@ string.
 
 > Code changes can be seen in [SearchBox.jsx](./frontend/src/components/SearchBox.jsx)
 
+### Bug: All file types are allowed when updating product images
+
+When updating product images as an Admin user, all file types are allowed. We only want to upload image files. This is fixed by using a fileFilter function and sending back an appropriate error when the wrong file type is uploaded.
+
+> Code changes can be seen in [uploadRoutes.js](./backend/routes/uploadRoutes.js)
+
 ---
 
 ## License


### PR DESCRIPTION
We have a checkFileType function in uploadRoutes.js that only allows image uploads, but it is never used in the middleware. These changes utilize that function and also responds with a  status code of 400 to the client when a non-image is uploaded.