### PR TITLE
fix: broken link of the product

### DIFF
--- a/frontend/src/screens/PlaceOrderScreen.jsx
+++ b/frontend/src/screens/PlaceOrderScreen.jsx
@@ -83,7 +83,7 @@ const PlaceOrderScreen = () => {
                           />
                         </Col>
                         <Col>
-                          <Link to={`/product/${item.product}`}>
+                          <Link to={`/product/${item._id}`}>
                             {item.name}
                           </Link>
                         </Col>


### PR DESCRIPTION
The link url which is inside the place order screen is wrong, it should be the id of the product that is passed to the url, there is no field named "product" in cart item.